### PR TITLE
Summoner 페이지 구현

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import { browser, instance, regionInstance } from './config';
 import { PATH } from '../constant';
@@ -30,6 +30,8 @@ export const API = {
     ),
   getInGameByPuuid: async (puuid: string) =>
     await instance.get(PATH.getInGameByPuuid.replace('{puuid}', puuid)),
+  getMasteryById: async (id: string) =>
+    await instance.get(PATH.getMasteryById.replace('{id}', id)),
 };
 
 export const CLIENT_API = {
@@ -49,4 +51,10 @@ export const CLIENT_API = {
   getRune: () => browser.get(PATH.getRune),
   getInGameByPuuid: async (puuid: string) =>
     await browser.get(BFF_PATH.getInGameByPuuid.replace('{puuid}', puuid)),
+  getMasteryById: async (id: string) =>
+    await browser.get(BFF_PATH.getMasteryById.replace('{id}', id)),
+  getChamp: async () =>
+    await browser.get(
+      'http://ddragon.leagueoflegends.com/cdn/13.1.1/data/en_US/champion.json'
+    ),
 };

--- a/components/masterySection/MasteryHeader.tsx
+++ b/components/masterySection/MasteryHeader.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react';
+
+import Typography from 'userInterface/typography/Typography';
+
+const MasteryHeader: FC = () => {
+  return (
+    <div className=' w-[800px] h-[60px] pt-3 flex shrink-0 grow-0 justify-center'>
+      <div className='basis-36'>
+        <Typography
+          type='default'
+          size='small'
+          color='gray'
+          string='Champion'
+        />
+      </div>
+      <div className='basis-36'>
+        <Typography type='default' size='small' color='gray' string='Icon' />
+      </div>
+      <div className='basis-36'>
+        <Typography type='default' size='small' color='gray' string='Level' />
+      </div>
+      <div className='basis-36'>
+        <Typography
+          type='default'
+          size='small'
+          color='gray'
+          string='Mastery Point'
+        />
+      </div>
+      <div className='basis-36'>
+        <Typography
+          type='default'
+          size='small'
+          color='gray'
+          string='PlayTime'
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MasteryHeader;

--- a/components/masterySection/MasteryRow.tsx
+++ b/components/masterySection/MasteryRow.tsx
@@ -1,0 +1,94 @@
+import moment from 'moment';
+import { FC } from 'react';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+import Typography from 'userInterface/typography/Typography';
+import ChampionIcon from 'components/championIcon/ChampionIcon';
+import { QUERY_KEYS } from 'constant';
+import { CLIENT_API } from 'api/api';
+import {
+  ChampDetails,
+  ChampionIconProps,
+  MasteryRowProps,
+  RiotChampInfo,
+  TypographyProps,
+} from 'types';
+
+const MasteryRow: FC<MasteryRowProps> = ({ masteryInfo }) => {
+  const { data: champData }: UseQueryResult<RiotChampInfo> = useQuery(
+    [QUERY_KEYS.getChamp],
+    CLIENT_API.getChamp
+  );
+  const { championLevel, championPoints, lastPlayTime, championId } =
+    masteryInfo;
+
+  // LastPlayTime
+  const convertedLastPlayTime =
+    String(moment(lastPlayTime).diff(moment(), 'days')).replace('-', '') +
+    '일전';
+
+  //Champ Name
+  const riotChampData = champData?.data as ChampDetails;
+  let champName = '';
+  const champDetail = Object.entries(riotChampData).find(
+    (champ) => champ[1]?.key === String(championId)
+  );
+
+  if (champDetail) {
+    champName = champDetail[0];
+  }
+
+  const ChampNameTypographyProps: TypographyProps = {
+    type: 'default',
+    size: 'small',
+    color: 'gray',
+    string: champName,
+  };
+
+  const ChampLevelTypographyProps: TypographyProps = {
+    type: 'default',
+    size: 'small',
+    color: 'gray',
+    string: String(championLevel),
+  };
+
+  const ChampPointTypographyProps: TypographyProps = {
+    type: 'default',
+    size: 'small',
+    color: 'gray',
+    string: String(championPoints),
+  };
+  const PlayTimeTypographyProps: TypographyProps = {
+    type: 'default',
+    size: 'small',
+    color: 'gray',
+    string: convertedLastPlayTime,
+  };
+
+  const ChampionIconProps: ChampionIconProps = {
+    width: 30,
+    championName: champName,
+  };
+
+  return (
+    <div className=' w-[800px] h-[60px] pt-3 flex shrink-0 grow-0 justify-center '>
+      <div className='basis-36'>
+        <Typography {...ChampNameTypographyProps} />
+      </div>
+      <div className='basis-36'>
+        <ChampionIcon {...ChampionIconProps} />
+      </div>
+      <div className='basis-36'>
+        <Typography {...ChampLevelTypographyProps} />
+      </div>
+      <div className='basis-36'>
+        <Typography {...ChampPointTypographyProps} />
+      </div>
+      <div className='basis-36'>
+        <Typography {...PlayTimeTypographyProps} />
+      </div>
+    </div>
+  );
+};
+
+export default MasteryRow;

--- a/components/masterySection/MasterySection.tsx
+++ b/components/masterySection/MasterySection.tsx
@@ -1,0 +1,67 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FC } from 'react';
+
+import Box from 'userInterface/box/Box';
+import Typography from 'userInterface/typography/Typography';
+import { CLIENT_API } from 'api/api';
+import { QUERY_KEYS } from 'constant';
+import {
+  BoxProps,
+  InGameInfo,
+  IngameSectionProps,
+  InGameTeamColumnProps,
+  InGameUser,
+  MasteryInfo,
+  MasteryRowProps,
+  QueueTypeMapper,
+  Response,
+  RiotChampInfo,
+  SummonerInfo,
+  TypographyProps,
+} from 'types';
+import axios from 'axios';
+import MasteryRow from './MasteryRow';
+import MasteryHeader from './MasteryHeader';
+
+const MasterySection: FC<IngameSectionProps> = ({ nickname }) => {
+  const { data: summonerResponse }: UseQueryResult<Response<SummonerInfo>> =
+    useQuery([QUERY_KEYS.getSummonerByNickname, { nickname }], () =>
+      CLIENT_API.getSummonerByNickname(nickname)
+    );
+
+  const { id } = summonerResponse?.items as SummonerInfo;
+
+  const { data: masteryResponse }: UseQueryResult<Response<MasteryInfo[]>> =
+    useQuery([QUERY_KEYS.getMasteryById, { nickname }], () =>
+      CLIENT_API.getMasteryById(id)
+    );
+  const masteryInfo = masteryResponse?.items as MasteryInfo[];
+
+  const GameModeTypoProps: TypographyProps = {
+    color: 'gray',
+    string: `${nickname} 의 챔피언 통계`,
+    type: 'title',
+  };
+
+  const BoxProps: BoxProps = {
+    size: 'custom',
+    width: 'w-[800px]',
+  };
+
+  return (
+    <section className='flex flex-col items-center my-32 mt-10 gap-y-10'>
+      <Typography {...GameModeTypoProps} />
+      <Box {...BoxProps}>
+        <MasteryHeader />
+        {masteryInfo.map((mastery) => {
+          const MasteryRowProps: MasteryRowProps = {
+            masteryInfo: mastery,
+          };
+
+          return <MasteryRow {...MasteryRowProps} />;
+        })}
+      </Box>
+    </section>
+  );
+};
+export default MasterySection;

--- a/components/masterySection/MasterySection.tsx
+++ b/components/masterySection/MasterySection.tsx
@@ -7,19 +7,13 @@ import { CLIENT_API } from 'api/api';
 import { QUERY_KEYS } from 'constant';
 import {
   BoxProps,
-  InGameInfo,
   IngameSectionProps,
-  InGameTeamColumnProps,
-  InGameUser,
   MasteryInfo,
   MasteryRowProps,
-  QueueTypeMapper,
   Response,
-  RiotChampInfo,
   SummonerInfo,
   TypographyProps,
 } from 'types';
-import axios from 'axios';
 import MasteryRow from './MasteryRow';
 import MasteryHeader from './MasteryHeader';
 
@@ -58,7 +52,7 @@ const MasterySection: FC<IngameSectionProps> = ({ nickname }) => {
             masteryInfo: mastery,
           };
 
-          return <MasteryRow {...MasteryRowProps} />;
+          return <MasteryRow {...MasteryRowProps} key={mastery.championId} />;
         })}
       </Box>
     </section>

--- a/constant/path.ts
+++ b/constant/path.ts
@@ -10,6 +10,7 @@ export const PATH = {
   getRune:
     'https://ddragon.leagueoflegends.com/cdn/13.1.1/data/en_US/runesReforged.json',
   getInGameByPuuid: 'spectator/v4/active-games/by-summoner/{puuid}',
+  getMasteryById: 'champion-mastery/v4/champion-masteries/by-summoner/{id}',
 };
 
 export const BFF_PATH = {
@@ -18,4 +19,5 @@ export const BFF_PATH = {
   getMatchArrByPuuid: '/api/getMatchIdArr?puuid={puuid}&count={count}',
   getGameByMatchId: '/api/getGame?matchId={matchId}',
   getInGameByPuuid: '/api/getInGame?puuid={puuid}',
+  getMasteryById: '/api/getMastery?id={id}',
 };

--- a/constant/queries.ts
+++ b/constant/queries.ts
@@ -7,4 +7,5 @@ export const QUERY_KEYS = {
   getRune: 'RiotRuneData',
   getInGameByPuuid: 'IngameInfo',
   getChamp: 'RiotChampData',
+  getMasteryById: 'MasteryInfo',
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@nivo/pie": "^0.80.0",
     "@tanstack/react-query": "^4.22.0",
     "axios": "^1.2.2",
+    "moment": "^2.29.4",
     "next": "13.1.2",
     "next-seo": "^5.15.0",
     "react": "18.2.0",

--- a/pages/api/getMastery.ts
+++ b/pages/api/getMastery.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosResponse } from 'axios';
+
+import { API } from 'api';
+import { Error, LeagueInfoArr, MasteryInfo, Response } from 'types';
+
+async function getMasteryById(id: string) {
+  const response: AxiosResponse<MasteryInfo[]> = await API.getMasteryById(id);
+  const masteryInfo: MasteryInfo[] = response.data;
+
+  return masteryInfo;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Response<MasteryInfo[]> | Error>
+) {
+  const { id } = req.query;
+  try {
+    const masteryInfo = await getMasteryById(String(id));
+    res.status(200).json({ items: masteryInfo, message: 'MasteryInfo' });
+  } catch (error) {
+    const message = 'Unknown Error';
+    const status = 500;
+
+    // if (error instanceof Error) {
+    //   message = error.message;
+    //   status = 500;
+    // }
+    res.status(500).json({ message: message, status: status });
+  }
+}

--- a/pages/search/[nickname]/summoner/index.tsx
+++ b/pages/search/[nickname]/summoner/index.tsx
@@ -1,0 +1,19 @@
+import { useRouter } from 'next/router';
+import { FC, Suspense } from 'react';
+
+import Profile from 'components/profile/Profile';
+import MasterySection from 'components/masterySection/MasterySection';
+
+const Summoner: FC = () => {
+  const router = useRouter();
+  const { nickname } = (router.query as { nickname: string }) || '';
+
+  return (
+    <Suspense fallback={<div>LOADING</div>}>
+      <Profile nickname={nickname} />
+      <MasterySection nickname={nickname} />
+    </Suspense>
+  );
+};
+
+export default Summoner;

--- a/types/index.ts
+++ b/types/index.ts
@@ -560,3 +560,36 @@ export interface InGameUserRowProps {
 export interface IngameSectionProps {
   nickname: string;
 }
+
+export type MasteryInfo = {
+  championId: number;
+  championLevel: number;
+  championPoints: number;
+  lastPlayTime: number;
+  championPointsSinceLastLevel: number;
+  championPointsUntilNextLevel: number;
+  chestGranted: boolean;
+  tokensEarned: number;
+  summonerId: string;
+};
+
+export type RiotChampInfo = {
+  data: ChampDetails;
+};
+
+export type ChampDetails = {
+  [index: string]: {
+    key: string;
+    name: string;
+    blurb: string;
+    id: string;
+    partype: string;
+    title: string;
+    stats: {};
+    info: {};
+  };
+};
+
+export interface MasteryRowProps {
+  masteryInfo: MasteryInfo;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,6 +3817,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"


### PR DESCRIPTION
#개요

- Mastery Section 구현
- Mastery 정보를 받은 후 Row 컴포넌트에 보이게 처리 (Day Diff 는 Moment 이용)
- json 파일 정보를 받아온후 챔피언 이름을 찾은 후 Image Component 처리

# 스크린샷 OR 바뀐점

<img width="300" height="300" alt="image" src="https://user-images.githubusercontent.com/62933450/215707943-9cd1e5d4-8d7f-48fb-9d11-0881a166594a.png">
