### PR TITLE
Tailwind global css의 apply로 css 간결하게 정리

### DIFF
--- a/components/champStatRow/ChampStatRow.props.ts
+++ b/components/champStatRow/ChampStatRow.props.ts
@@ -31,5 +31,5 @@ export const ChampionIconPropsMapper = (
   width: 30,
   championName,
   championLevel: undefined,
-  marginClass: 'mt-2',
+  mt: 2,
 });

--- a/components/champStatRow/ChampStatRow.tsx
+++ b/components/champStatRow/ChampStatRow.tsx
@@ -21,13 +21,13 @@ const ChampStatRow: FC<ChampStatRowProps> = ({ champInfo }) => {
   return (
     <div className='flex items-center gap-3 my-2'>
       <ChampionIcon {...ChampionIconProps} />
-      <div className='w-[80px]'>
+      <div className='w-20'>
         <Typography {...ChampKdaProps} />
       </div>
-      <div className='w-[50px]'>
+      <div className='w-12.5'>
         <Typography {...WinProps} />
       </div>
-      <div className='w-[50px]'>
+      <div className='w-12.5'>
         <Typography {...WinRateProps} />
       </div>
     </div>

--- a/components/championIcon/ChampionIcon.tsx
+++ b/components/championIcon/ChampionIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FC } from 'react';
 
 import CustomImage from 'userInterface/customImage/CustomImage';
@@ -9,17 +10,42 @@ const ChampionIcon: FC<ChampionIconProps> = ({
   width,
   championName,
   championLevel,
-  marginClass,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mb,
+  mr,
+  mt,
 }) => {
   const championSource = IMAGES.CHAMPION.replace('{champion}', championName);
-
-  const wrapper =
-    `w-[${width}px] flex-col text-white text-start` + ' ' + marginClass;
-
   const CustomImageProps = CustomImagePropsMapper(championSource, width);
 
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const wrapperClassName = classNames(
+    'flex-col text-white text-start',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper,
+    `w-[${width}px]`
+  );
+
+
   return (
-    <div className={wrapper}>
+    <div className={wrapperClassName}>
       <CustomImage {...CustomImageProps} />
       <span className='absolute -translate-y-3.75 bg-black rounded-full text-sm'>
         {championLevel}

--- a/components/championIcon/ChampionIcon.tsx
+++ b/components/championIcon/ChampionIcon.tsx
@@ -21,7 +21,7 @@ const ChampionIcon: FC<ChampionIconProps> = ({
   return (
     <div className={wrapper}>
       <CustomImage {...CustomImageProps} />
-      <span className='absolute translate-y-[-15px] bg-black rounded-full text-sm'>
+      <span className='absolute -translate-y-3.75 bg-black rounded-full text-sm'>
         {championLevel}
       </span>
     </div>

--- a/components/championIcon/ChampionIcon.types.ts
+++ b/components/championIcon/ChampionIcon.types.ts
@@ -2,5 +2,12 @@ export interface ChampionIconProps {
   width: number;
   championName: string;
   championLevel?: number;
-  marginClass?: string;
+  mt?: number;
+  ml?: number;
+  mr?: number;
+  mb?: number;
+  pt?: number;
+  pl?: number;
+  pr?: number;
+  pb?: number;
 }

--- a/components/detailSection/DetailSection.props.ts
+++ b/components/detailSection/DetailSection.props.ts
@@ -8,9 +8,8 @@ import {
 } from 'types';
 
 export const TeamBoxMapper = (color: keyof BoxColorMapper): BoxProps => ({
-  size: 'custom',
-  height: 'h-[350px]',
-  width: 'w-full',
+  height: 'bgSection',
+  width: 'full',
   color,
 });
 

--- a/components/detailSectionHeader/DetailSectionHeader.props.ts
+++ b/components/detailSectionHeader/DetailSectionHeader.props.ts
@@ -1,8 +1,8 @@
 import { DetailHeaderColorMapper, TypographyProps } from 'types';
 
 export const ColorMapper: DetailHeaderColorMapper = {
-  red: 'flex w-full h-[35px] border-b-2 border-red-200 pl-5 gap-x-1',
-  blue: 'flex w-full h-[35px] border-b-2 border-blue-200 pl-5 gap-x-1',
+  red: 'flex w-full h-8.75 border-b-2 border-red-200 pl-5 gap-x-1',
+  blue: 'flex w-full h-8.75 border-b-2 border-blue-200 pl-5 gap-x-1',
 };
 
 export const ChampKeyProps: TypographyProps = {

--- a/components/detailSectionHeader/DetailSectionHeader.tsx
+++ b/components/detailSectionHeader/DetailSectionHeader.tsx
@@ -16,22 +16,22 @@ import {
 const DetailSectionHeader: FC<DetailSectionHeaderProps> = ({ color }) => {
   return (
     <div className={ColorMapper[color]}>
-      <div className='w-[75px] pt-2'>
+      <div className='pt-2 w-19'>
         <Typography {...ChampKeyProps} />
       </div>
-      <div className='w-[75px] pt-2'>
+      <div className='pt-2 w-19'>
         <Typography {...KdaKeyProps} />
       </div>
-      <div className='w-[100px] pt-2'>
+      <div className='pt-2 w-25'>
         <Typography {...NicknameKeyProps} />
       </div>
-      <div className='w-[80px] pt-2'>
+      <div className='w-20 pt-2'>
         <Typography {...StatKeyProps} />
       </div>
-      <div className='w-[105px] pt-2'>
+      <div className='pt-2 w-21'>
         <Typography {...DamageBarChartKeyProps} />
       </div>
-      <div className='w-[140px] pt-2'>
+      <div className='pt-2 w-35'>
         <Typography {...DamagedBarChartKeyProps} />
       </div>
       <div className='pt-2'>

--- a/components/inGameSection/InGameSection.props.ts
+++ b/components/inGameSection/InGameSection.props.ts
@@ -29,9 +29,8 @@ export const VersusProps: TypographyProps = {
 };
 
 export const InGameBoxProps: BoxProps = {
-  size: 'custom',
-  height: 'h-[350px]',
-  width: 'w-[800px]',
+  height: 'bgSection',
+  width: 'bgSection',
   color: 'blue',
 };
 

--- a/components/inGameUserRow/InGameUserRow.props.ts
+++ b/components/inGameUserRow/InGameUserRow.props.ts
@@ -17,13 +17,13 @@ export const NicknamePropsMapper = (nickname: string): TypographyProps => ({
 export const SpellIconPropsMapper = (spells: SpellInfos): SpellIconProps => ({
   spells: spells,
   width: 25,
-  marginClass: 'pt-1',
+  pt: 1,
 });
 
 export const RuneIconPropsMapper = (runes: RuneInfo[]): RuneIconProps => ({
   runes,
   width: 25,
-  marginClass: 'pt-1',
+  pt: 1,
 });
 
 export const ProfileIconPropsMapper = (

--- a/components/inGameUserRow/InGameUserRow.tsx
+++ b/components/inGameUserRow/InGameUserRow.tsx
@@ -24,17 +24,17 @@ const InGameUserRow: FC<InGameUserRowProps> = ({
   const ProfileIconProps = ProfileIconPropsMapper(profileIconId);
 
   return (
-    <div className='flex w-[300px] h-[60px] mx-5 mt-1 items-center'>
-      <div className='w-[70px] translate-x-[-40px]'>
+    <div className='flex items-center mx-5 mt-1 w-sm-section h-15'>
+      <div className='-translate-x-10 w-18'>
         <ProfileIcon {...ProfileIconProps} />
       </div>
-      <div className='w-[30px]'>
+      <div className='w-8'>
         <SpellIcon {...SpellIconProps} />
       </div>
-      <div className='w-[40px]'>
+      <div className='w-10'>
         <RuneIcon {...RuneIconProps} />
       </div>
-      <div className='ml-5 w-[100]px'>
+      <div className='ml-5 w-25'>
         <Typography {...NicknameProps} />
       </div>
     </div>

--- a/components/itemIcon/ItemIcon.tsx
+++ b/components/itemIcon/ItemIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { v4 as uuidv4 } from 'uuid';
 import { FC } from 'react';
 
@@ -6,11 +7,40 @@ import { IMAGES } from 'constant';
 import { ItemIconProps } from './ItemIcon.types';
 import { CustomImagePropsMapper } from './ItemIcon.props';
 
-const ItemIcon: FC<ItemIconProps> = ({ width, summonerItems, marginClass }) => {
-  const wrapper = 'flex' + ' ' + marginClass;
+const ItemIcon: FC<ItemIconProps> = ({
+  width,
+  summonerItems,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mr,
+  mt,
+  mb,
+}) => {
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const wrapperClassName = classNames(
+    'flex',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper
+  );
 
   return (
-    <div className={wrapper}>
+    <div className={wrapperClassName}>
       {summonerItems?.map((item) => {
         const itemSource = IMAGES.ITEM.replace('{item}', String(item));
         const CustomImageProps = CustomImagePropsMapper(itemSource, width);

--- a/components/kda/Kda.tsx
+++ b/components/kda/Kda.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FC } from 'react';
 
 import Typography from 'userInterface/typography/Typography';
@@ -14,16 +15,41 @@ const Kda: FC<KdaProps> = ({
   deaths,
   assists,
   kda,
-  marginClass,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mb,
+  mr,
+  mt,
   size = 'medium',
   kdaSize = 'small',
 }) => {
-  const wrapperClassName = 'flex-col' + ' ' + marginClass;
-
   const KillsProps = KillsPropsMapper(kills, size);
   const DeathsProps = DeathsPropsMapper(deaths, size);
   const AssistsProps = AssistsPropsMapper(assists, size);
   const KdaProps = KdaPropsMapper(kda, kdaSize);
+
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const wrapperClassName = classNames(
+    'flex-col',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper
+  );
 
   return (
     <div className={wrapperClassName}>

--- a/components/kda/Kda.types.ts
+++ b/components/kda/Kda.types.ts
@@ -5,7 +5,14 @@ export interface KdaProps {
   deaths: number;
   assists: number;
   kda?: number;
-  marginClass?: string;
+  mt?: number;
+  ml?: number;
+  mr?: number;
+  mb?: number;
+  pt?: number;
+  pl?: number;
+  pr?: number;
+  pb?: number;
   size?: keyof TypoGraphySizeMapper;
   kdaSize?: keyof TypoGraphySizeMapper;
 }

--- a/components/masteryHeader/MasteryHeader.tsx
+++ b/components/masteryHeader/MasteryHeader.tsx
@@ -11,7 +11,7 @@ import {
 
 const MasteryHeader: FC = () => {
   return (
-    <div className=' w-[800px] h-[60px] pt-3 flex shrink-0 grow-0 justify-center'>
+    <div className='center w-bg-section h-15'>
       <div className='basis-36'>
         <Typography {...ChampionKeyProps} />
       </div>

--- a/components/masteryRow/MasteryRow.tsx
+++ b/components/masteryRow/MasteryRow.tsx
@@ -25,7 +25,7 @@ const MasteryRow: FC<MasteryRowProps> = ({ masteryInfo }) => {
   const ChampionIconProps = IconPropsMapper(champName);
 
   return (
-    <div className=' w-[800px] h-[60px] pt-3 flex shrink-0 grow-0 justify-center '>
+    <div className='pt-3 center w-bg-section h-15 shrink-0 grow-0 '>
       <div className='basis-36'>
         <Typography {...ChampNameProps} />
       </div>

--- a/components/masterySection/MasterySection.props.ts
+++ b/components/masterySection/MasterySection.props.ts
@@ -7,8 +7,7 @@ export const GameModePropsMapper = (nickname: string): TypographyProps => ({
 });
 
 export const MasteryBoxProps: BoxProps = {
-  size: 'custom',
-  width: 'w-[800px]',
+  width: 'bgSection',
 };
 
 export const AsyncBoundaryPropsMapper = (key: string) => ({

--- a/components/matchCard/MatchCard.props.ts
+++ b/components/matchCard/MatchCard.props.ts
@@ -49,7 +49,7 @@ export const CardBoxPropsMapper = (
   height: 'smSection',
   width: 'full',
   color: isWin ? 'blue' : 'red',
-  marginClass: isShownDetail ? '' : 'mb-2',
+  mb: isShownDetail ? '' : '2',
 });
 
 export const MatchSummonerOverViewPropsMapper = (

--- a/components/matchCard/MatchCard.props.ts
+++ b/components/matchCard/MatchCard.props.ts
@@ -46,9 +46,8 @@ export const CardBoxPropsMapper = (
   isWin: boolean,
   isShownDetail: boolean
 ): BoxProps => ({
-  size: 'custom',
-  height: 'h-32',
-  width: 'w-full',
+  height: 'smSection',
+  width: 'full',
   color: isWin ? 'blue' : 'red',
   marginClass: isShownDetail ? '' : 'mb-2',
 });

--- a/components/matchCard/MatchCard.props.ts
+++ b/components/matchCard/MatchCard.props.ts
@@ -49,8 +49,8 @@ export const CardBoxPropsMapper = (
   height: 'smSection',
   width: 'full',
   color: isWin ? 'blue' : 'red',
-  mb: isShownDetail ? '' : '2',
-  mt: '2',
+  mb: isShownDetail ? 0 : 2,
+  mt: 2,
 });
 
 export const MatchSummonerOverViewPropsMapper = (

--- a/components/matchCard/MatchCard.props.ts
+++ b/components/matchCard/MatchCard.props.ts
@@ -50,6 +50,7 @@ export const CardBoxPropsMapper = (
   width: 'full',
   color: isWin ? 'blue' : 'red',
   mb: isShownDetail ? '' : '2',
+  mt: '2',
 });
 
 export const MatchSummonerOverViewPropsMapper = (

--- a/components/matchOverView/MatchOverView.tsx
+++ b/components/matchOverView/MatchOverView.tsx
@@ -22,7 +22,7 @@ const MatchOverView: FC<MatchOverViewProps> = ({
   const GameTimeProps = GameTimePropsMapper(gameTime);
 
   return (
-    <div className='flex flex-col py-5 ml-5 gap-y-[1px] w-[80px]'>
+    <div className='flex flex-col w-20 py-5 ml-5 gap-y-px'>
       <Typography {...MatchTypeProps} />
       <Typography {...DayDiffProps} />
       <Divider />

--- a/components/matchSummonerOverView/MatchSummonerOverView.props.ts
+++ b/components/matchSummonerOverView/MatchSummonerOverView.props.ts
@@ -39,7 +39,7 @@ export const ItemIconPropsMapper = (
 ): ItemIconProps => ({
   summonerItems,
   width: 25,
-  marginClass: 'mt-3',
+  mt: 3,
 });
 
 export const KdaPropsMapper = (
@@ -52,19 +52,20 @@ export const KdaPropsMapper = (
   deaths: deaths,
   assists: assists,
   kda: kda,
-  marginClass: 'mt-2 ml-2',
+  mt: 2,
+  ml: 2,
 });
 
 export const RuneIconPropsMapper = (runes: RuneInfo[]): RuneIconProps => ({
   runes: runes,
   width: 25,
-  marginClass: 'ml-1',
+  ml: 1,
 });
 
 export const SpellIconPropsMapper = (spells: SpellInfos): SpellIconProps => ({
   spells: spells,
   width: 25,
-  marginClass: 'ml-2',
+  ml: 2,
 });
 
 export const ChampionIconPropsMapper = (

--- a/components/matchSummonerOverView/MatchSummonerOverView.tsx
+++ b/components/matchSummonerOverView/MatchSummonerOverView.tsx
@@ -53,8 +53,8 @@ const MatchSummonerOverView: FC<MatchSummonerOverViewProps> = ({
   );
 
   return (
-    <div className='flex w-[700px] py-5 ml-10'>
-      <div className='flex-col w-[200px]'>
+    <div className='flex py-5 ml-10'>
+      <div className='col w-52'>
         <div className='flex'>
           <ChampionIcon {...ChampionIconProps} />
           <SpellIcon {...SpellIconProps} />
@@ -63,13 +63,13 @@ const MatchSummonerOverView: FC<MatchSummonerOverViewProps> = ({
         </div>
         <ItemIcon {...ItemIconProps} />
       </div>
-      <div className='flex w-[150px] flex-col justify-center ml-5 border-l-2-slate-300'>
+      <div className='w-37.5 col justify-center ml-5 border-l-2-slate-300'>
         <Typography {...KillProps} />
         <Typography {...CsProps} />
         <Typography {...VisionScoreProps} />
         <Typography {...GoldProps} />
       </div>
-      <div className='flex w-[280px]'>
+      <div className='flex w-70 gap-x-7'>
         <TeamChampion {...SummonerTeamChampionProps} />
         <TeamChampion {...EnemyTeamChampionProps} />
       </div>

--- a/components/profile/Profile.props.ts
+++ b/components/profile/Profile.props.ts
@@ -56,5 +56,5 @@ export const SummonerNamePropsMapper = (name: string): TypographyProps => ({
 });
 
 export const ProfileBoxProps: BoxProps = {
-  size: 'full',
+  width: 'full',
 };

--- a/components/profileIcon/ProfileIcon.tsx
+++ b/components/profileIcon/ProfileIcon.tsx
@@ -16,10 +16,10 @@ const ProfileIcon: FC<ProfileIconProps> = ({
   const CustomImageProps = CustomImagePropsMapper(source, width);
 
   return (
-    <div className='flex-col w-[140px] mx-3 my-5 font-medium flex items-center'>
+    <div className='flex flex-col items-center mx-3 my-5 font-medium w-35'>
       <CustomImage {...CustomImageProps} />
       {summonerLevel && (
-        <p className='w-[50px] text-white bg-black border text-center rounded-xl'>
+        <p className='w-12.5 text-white bg-black border text-center rounded-xl'>
           {summonerLevel}
         </p>
       )}

--- a/components/rankCard/RankCard.props.ts
+++ b/components/rankCard/RankCard.props.ts
@@ -15,8 +15,8 @@ const rankTitleMapper: RankTitleMapper = {
 };
 
 export const RankCardBoxProps: BoxProps = {
-  size: 'custom',
-  width: 'w-[300px] max-sm:hidden',
+  width: 'smSection',
+  hidden: 'sm',
 };
 
 export const LpPropsMapper = (

--- a/components/rankCard/RankCard.tsx
+++ b/components/rankCard/RankCard.tsx
@@ -38,9 +38,9 @@ const RankCard: FC<RankCardProps> = ({
         <Typography {...LpProps} />
         <div className='flex items-center'>
           <Image {...ImageProps} />
-          <div className='flex items-center w-[240px] h-[100px] my-5'>
+          <div className='flex items-center my-5 w-60 h-25'>
             <PieChart {...PieChartProps} />
-            <p className='translate-x-[-127px]'>{winRate}</p>
+            <p className='-translate-x-32'>{winRate}</p>
           </div>
         </div>
       </div>

--- a/components/resentStatSection/RecentStatSection.props.ts
+++ b/components/resentStatSection/RecentStatSection.props.ts
@@ -7,8 +7,8 @@ import {
 } from 'types';
 
 export const RecentStatBoxProps: BoxProps = {
-  size: 'custom',
-  width: 'w-[300px] max-sm:hidden',
+  width: 'smSection',
+  hidden: 'sm',
 };
 
 export const PieChartPropsMapper = (winStats: recentWinInfo) => ({

--- a/components/resentStatSection/RecentStatSection.tsx
+++ b/components/resentStatSection/RecentStatSection.tsx
@@ -28,9 +28,9 @@ const RecentStatSection: FC = () => {
       <Box {...RecentStatBoxProps}>
         <div className='items-center mx-2 my-3 divide-y'>
           <Typography {...RecentMatchProps} />
-          <div className='w-[300px] h-[150px] mb-10'>
+          <div className='w-75 h-37.5 mb-10'>
             <PieChart {...PieChartProps} />
-            <div className='translate-x-[109px] translate-y-[-68px]'>
+            <div className='translate-x-27 -translate-y-17'>
               <Typography {...WinRateProps} />
             </div>
           </div>

--- a/components/runeIcon/RuneIcon.tsx
+++ b/components/runeIcon/RuneIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FC } from 'react';
 
 import CustomImage from 'userInterface/customImage/CustomImage';
@@ -5,11 +6,40 @@ import { IMAGES } from 'constant';
 import { RuneIconProps, RuneInfo } from './RuneIcon.types';
 import { CustomImagePropsMapper } from './RuneIcon.props';
 
-const RuneIcon: FC<RuneIconProps> = ({ width, runes, marginClass }) => {
-  const wrapper = 'flex-col gap-y-1' + ' ' + String(marginClass);
+const RuneIcon: FC<RuneIconProps> = ({
+  width,
+  runes,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mr,
+  mt,
+  mb,
+}) => {
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const wrapperClassName = classNames(
+    'flex-col gap-y-1',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper
+  );
 
   return (
-    <div className={wrapper}>
+    <div className={wrapperClassName}>
       {runes.map((runeInfo: RuneInfo) => {
         const runeSource = IMAGES.RUNE.replace('{rune}', runeInfo.icon);
         const CustomImageProps = CustomImagePropsMapper(runeSource, width);

--- a/components/searchWindow/SearchWindow.tsx
+++ b/components/searchWindow/SearchWindow.tsx
@@ -37,7 +37,7 @@ const SearchWindow: FC<SearchWindowProps> = ({ mini = false }) => {
         <div className='flex flex-row justify-center w-full justify-items-center'>
           <AiOutlineSearch {...MiniIconProps} />
           <Input {...MiniInputProps} />
-          <div className='translate-x-[-55px] translate-y-[7px]'>
+          <div className='-translate-x-13.5 translate-y-1.5'>
             <Button {...MiniButtonProps} />
           </div>
         </div>

--- a/components/singleBarChart/SingleBarChart.tsx
+++ b/components/singleBarChart/SingleBarChart.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FC } from 'react';
 
 import Typography from 'userInterface/typography/Typography';
@@ -16,12 +17,19 @@ const SingleBarChart: FC<SingleBarChartProps> = ({
   endColor,
   width,
   height,
-  marginClass = '',
   titleSize,
   titleColor,
   valueSize,
   valueColor,
   isValueShow,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mb,
+  mr,
+  mt,
 }) => {
   const colorMapper: SingleBarColorMapper = {
     red: 'bg-red-400',
@@ -30,7 +38,25 @@ const SingleBarChart: FC<SingleBarChartProps> = ({
     gray: 'bg-gray-500',
   };
 
-  const className = 'flex flex-col items-center' + ' ' + marginClass;
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const className = classNames(
+    'items-center col',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper
+  );
 
   const startRate = startValue / totalValue;
   const startWidth = width * startRate;

--- a/components/singleBarChart/SingleBarChart.types.ts
+++ b/components/singleBarChart/SingleBarChart.types.ts
@@ -16,7 +16,14 @@ export interface SingleBarChartProps {
   startColor: keyof SingleBarColorMapper;
   endColor: keyof SingleBarColorMapper;
   endValue?: string | number;
-  marginClass?: string;
+  mt?: number;
+  ml?: number;
+  mr?: number;
+  mb?: number;
+  pt?: number;
+  pl?: number;
+  pr?: number;
+  pb?: number;
   titleSize?: keyof TypoGraphySizeMapper;
   titleColor?: keyof TypoGraphyColorMapper;
   valueSize?: keyof TypoGraphySizeMapper;

--- a/components/spellIcon/SpellIcon.tsx
+++ b/components/spellIcon/SpellIcon.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FC } from 'react';
 
 import CustomImage from 'userInterface/customImage/CustomImage';
@@ -5,11 +6,40 @@ import { IMAGES } from 'constant';
 import { SpellIconProps } from './SpellIcon.types';
 import { CustomImagePropsMapper } from './SpellIcon.props';
 
-const SpellIcon: FC<SpellIconProps> = ({ width, spells, marginClass }) => {
-  const wrapper = 'flex-col gap-y-1' + ' ' + marginClass;
+const SpellIcon: FC<SpellIconProps> = ({
+  width,
+  spells,
+  pt,
+  pl,
+  pr,
+  pb,
+  ml,
+  mr,
+  mt,
+  mb,
+}) => {
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
+  const ptMapper = pt ? `mt-${pt}` : '';
+  const pbMapper = pb ? `mb-${pb}` : '';
+  const plMapper = pl ? `ml-${pl}` : '';
+  const prMapper = pr ? `mt-${pr}` : '';
+  const wrapperClassName = classNames(
+    'flex-col gap-y-1',
+    mtMapper,
+    mbMapper,
+    mlMapper,
+    mrMapper,
+    ptMapper,
+    pbMapper,
+    plMapper,
+    prMapper
+  );
 
   return (
-    <div className={wrapper}>
+    <div className={wrapperClassName}>
       {spells?.map((spellName) => {
         const spellSource = IMAGES.SPELL.replace('{spell}', spellName[0]);
         const CustomImageProps = CustomImagePropsMapper(spellSource, width);

--- a/components/userStatRow/UserStatRow.props.ts
+++ b/components/userStatRow/UserStatRow.props.ts
@@ -23,13 +23,13 @@ export const ChampionIconPropsMapper = (
 export const RuneIconPropsMapper = (runes: RuneInfo[]): RuneIconProps => ({
   runes: runes,
   width: 15,
-  marginClass: 'pt-1',
+  pt: 1,
 });
 
 export const SpellIconPropsMapper = (spells: SpellInfos): SpellIconProps => ({
   spells: spells,
   width: 15,
-  marginClass: 'pt-1',
+  pt: 1,
 });
 
 export const KdaPropsMapper = (
@@ -42,7 +42,8 @@ export const KdaPropsMapper = (
   deaths: deaths,
   assists: assists,
   kda: kda,
-  marginClass: 'mt-2 ml-5',
+  mt: 2,
+  ml: 5,
   size: 'xSmall',
   kdaSize: 'xSmall',
 });
@@ -79,5 +80,5 @@ export const ItemIconPropsMapper = (
 ): ItemIconProps => ({
   summonerItems,
   width: 25,
-  marginClass: 'pt-7',
+  pt: 7,
 });

--- a/components/userStatRow/UserStatRow.tsx
+++ b/components/userStatRow/UserStatRow.tsx
@@ -99,14 +99,14 @@ const UserStatRow: FC<UserStatRowProps> = ({
   ]);
 
   return (
-    <div className='w-[800px] h-[60px] justify-center flex items-center gap-x-1 '>
-      <div className='flex w-[150px] pt-2'>
+    <div className='w-bg-section h-15 center gap-x-1 '>
+      <div className='flex w-37.5 pt-2'>
         <ChampionIcon {...ChampionIconProps} />
         <SpellIcon {...SpellIconProps} />
         <RuneIcon {...RuneIconProps} />
         <Kda {...KdaProps} />
       </div>
-      <div className='flex w-[100px] pt-4'>
+      <div className='flex pt-4 w-25'>
         <Link
           href={{
             pathname: '/search/[nickname]',
@@ -117,11 +117,11 @@ const UserStatRow: FC<UserStatRowProps> = ({
           <Typography {...NicknameProps} />
         </Link>
       </div>
-      <div className='flex-col w-[80px] pt-4'>
+      <div className='w-20 pt-4 col'>
         <Typography {...CsProps} />
         <Typography {...VisionScoreProps} />
       </div>
-      <div className='flex w-[250px] gap-x-3 pt-2'>
+      <div className='flex w-62.5 gap-x-3 pt-2'>
         <SingleBarChart {...DamageChartProps} />
         <SingleBarChart {...DamagedChartProps} />
       </div>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@nivo/pie": "^0.80.0",
     "@tanstack/react-query": "^4.22.0",
     "axios": "^1.2.2",
+    "classnames": "^2.3.2",
     "moment": "^2.29.4",
     "next": "13.1.2",
     "next-seo": "^5.15.0",

--- a/pages/ErrorBoundary.tsx
+++ b/pages/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 
 import Box from 'userInterface/box/Box';
 import Typography from 'userInterface/typography/Typography';
-import { ErrorBoxProps, ErrorTextPropsMapper } from 'types';
+import { BoxProps, TypographyProps } from 'types';
 
 interface Props {
   children?: ReactNode;
@@ -13,6 +13,18 @@ interface State {
   error: string;
 }
 
+export const ErrorBoxProps: BoxProps = {
+  height: 'bgSection',
+  width: 'bgSection',
+  ml: 'auto',
+  mr: 'auto',
+};
+
+export const ErrorTextPropsMapper = (error: string): TypographyProps => ({
+  type: 'title',
+  text: error,
+});
+
 class ErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,
@@ -20,12 +32,11 @@ class ErrorBoundary extends Component<Props, State> {
   };
 
   public static getDerivedStateFromError(error: Error): State {
-    // Update state so the next render will show the fallback UI.
     return { hasError: true, error: error.message };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Uncaught error:', 'ㄸㄲ꺆', error, 'ㅑㅜ럐', errorInfo);
+    console.error('Uncaught error:', error, errorInfo);
   }
 
   public render() {
@@ -34,7 +45,7 @@ class ErrorBoundary extends Component<Props, State> {
 
     if (error) {
       return (
-        <div className='ml-auto mr-auto text-xl text-center w-bg-section h-bg-section'>
+        <div className='ml-auto mr-auto text-center h-bg-section'>
           <Box {...ErrorBoxProps}>
             <div className='mt-7'>
               <Typography {...ErrorTextProps} />

--- a/pages/ErrorBoundary.tsx
+++ b/pages/ErrorBoundary.tsx
@@ -16,8 +16,6 @@ interface State {
 export const ErrorBoxProps: BoxProps = {
   height: 'bgSection',
   width: 'bgSection',
-  ml: 'auto',
-  mr: 'auto',
 };
 
 export const ErrorTextPropsMapper = (error: string): TypographyProps => ({
@@ -45,7 +43,7 @@ class ErrorBoundary extends Component<Props, State> {
 
     if (error) {
       return (
-        <div className='ml-auto mr-auto text-center h-bg-section'>
+        <div className='m-auto text-center mt-7 h-bg-section w-bg-section'>
           <Box {...ErrorBoxProps}>
             <div className='mt-7'>
               <Typography {...ErrorTextProps} />

--- a/pages/ErrorBoundary.tsx
+++ b/pages/ErrorBoundary.tsx
@@ -34,7 +34,7 @@ class ErrorBoundary extends Component<Props, State> {
 
     if (error) {
       return (
-        <div className='w-[800px] h-[300px] mr-auto ml-auto text-center text-xl'>
+        <div className='ml-auto mr-auto text-xl text-center w-bg-section h-bg-section'>
           <Box {...ErrorBoxProps}>
             <div className='mt-7'>
               <Typography {...ErrorTextProps} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import { TitleProps } from 'types';
 const Home: NextPage = () => {
   return (
     <AsyncBoundary>
-      <section className='flex flex-col items-center w-full my-10 duration-700 animate-pulse'>
+      <section className='search-section'>
         <Typography {...TitleProps} />
         <SearchWindow />
       </section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import { TitleProps } from 'types';
 const Home: NextPage = () => {
   return (
     <AsyncBoundary>
-      <section className='search-section'>
+      <section className='items-center w-full my-10 col pulse'>
         <Typography {...TitleProps} />
         <SearchWindow />
       </section>

--- a/pages/search/[nickname]/index.tsx
+++ b/pages/search/[nickname]/index.tsx
@@ -11,6 +11,7 @@ import { AsyncBoundaryPropsMapper, SectionPropsMapper } from 'types';
 
 const Search: FC = () => {
   const nickname = useRouter().query.nickname as string;
+
   const AsyncBoundaryProps = AsyncBoundaryPropsMapper(nickname);
   const SectionProps = SectionPropsMapper(nickname);
 

--- a/pages/search/[nickname]/index.tsx
+++ b/pages/search/[nickname]/index.tsx
@@ -18,15 +18,15 @@ const Search: FC = () => {
   return (
     <AsyncBoundary {...AsyncBoundaryProps}>
       <SearchLayout>
-        <div className='w-[1110px] max-lg:w-[800px]'>
+        <div className='w-full-section'>
           <Profile {...SectionProps} />
         </div>
         <div className='flex'>
-          <div className='w-[300px] max-lg:hidden mr-3'>
+          <div className='mt-2 mr-3 w-sm-section max-lg:hidden'>
             <RankSection {...SectionProps} />
             <RecentStatSection />
           </div>
-          <div className='w-[800px]'>
+          <div className='w-bg-section'>
             <MatchSection {...SectionProps} />
           </div>
         </div>

--- a/pages/search/[nickname]/summoner/index.tsx
+++ b/pages/search/[nickname]/summoner/index.tsx
@@ -9,6 +9,7 @@ import { AsyncBoundaryPropsMapper, SectionPropsMapper } from 'types';
 const Summoner: FC = () => {
   const router = useRouter();
   const { nickname } = (router.query as { nickname: string }) || '';
+
   const AsyncBoundaryProps = AsyncBoundaryPropsMapper(nickname);
   const SectionProps = SectionPropsMapper(nickname);
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,6 @@
 @tailwind base;
-@tailwind components;
 @tailwind utilities;
+@tailwind components;
 
 /* Typography */
 .main-title {
@@ -28,4 +28,26 @@
 }
 .input-large {
   @apply w-full text-lg
-} 
+}
+
+/* Button */
+.button-blue {
+  @apply text-white bg-blue-700 hover:bg-blue-500
+}
+.button-gray {
+  @apply text-white bg-gray-700 hover:bg-gray-500
+}
+.button-transparent {
+  @apply hover:border-blue-500 border-transparent border-2
+}
+.button-small {
+  @apply text-xs
+}
+.button-medium {
+  @apply text-sm
+}
+.button-large {
+  @apply text-lg
+}
+
+/* Box */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Typography */
+.main-title {
+  @apply bg-gradient-to-br from-black to-stone-500 bg-clip-text text-center text-6xl font-bold tracking-[-0.02em] text-transparent drop-shadow-sm leading-[5rem] my-20
+}
+.title {
+  @apply text-2xl font-medium
+}
+.semi-bold {
+  @apply font-semibold
+}
+
+/* Input */
+.input-blue {
+  @apply border border-blue-300 focus:border-gray-500
+}
+.input-gray {
+  @apply border border-gray-300 focus:border-blue-500
+}
+.input-small {
+  @apply w-1/5 text-xs
+}
+.input-medium {
+  @apply w-3/5 text-sm
+}
+.input-large {
+  @apply w-full text-lg
+} 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -75,3 +75,8 @@
 .box-blue {
   @apply bg-blue-100
 }
+
+/* Main Search Section */
+.search-section {
+  @apply flex flex-col items-center w-full my-10 duration-700 animate-pulse
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -58,7 +58,7 @@
   @apply w-[800px]
 }
 .w-sm-section {
-  @apply w-[350px]
+  @apply w-[300px]
 }
 .h-bg-section {
   @apply h-[350px]

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,35 @@
 @tailwind utilities;
 @tailwind components;
 
+/* 공용 */
+.w-full-section {
+  @apply w-[1100px] max-lg:w-[800px]
+}
+.w-full-to-bg {
+  @apply max-lg:w-[800px]
+}
+.w-bg-section {
+  @apply w-[800px]
+}
+.w-sm-section {
+  @apply w-[300px]
+}
+.h-bg-section {
+  @apply h-[350px]
+}
+.h-sm-section {
+  @apply h-32
+}
+.col {
+  @apply flex flex-col
+}
+.pulse {
+  @apply duration-700 animate-pulse
+}
+.center {
+  @apply justify-center flex items-center
+}
+
 /* Typography */
 .main-title {
   @apply bg-gradient-to-br from-black to-stone-500 bg-clip-text text-center text-6xl font-bold tracking-[-0.02em] text-transparent drop-shadow-sm leading-[5rem] my-20
@@ -54,18 +83,6 @@
 .box {
   @apply overflow-hidden border border-gray-200 shadow-md rounded-xl
 }
-.w-bg-section {
-  @apply w-[800px]
-}
-.w-sm-section {
-  @apply w-[300px]
-}
-.h-bg-section {
-  @apply h-[350px]
-}
-.h-sm-section {
-  @apply h-32
-}
 .box-default-color {
   @apply bg-white
 }
@@ -74,9 +91,4 @@
 }
 .box-blue {
   @apply bg-blue-100
-}
-
-/* Main Search Section */
-.search-section {
-  @apply flex flex-col items-center w-full my-10 duration-700 animate-pulse
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -54,3 +54,24 @@
 .box {
   @apply overflow-hidden border border-gray-200 shadow-md rounded-xl
 }
+.w-bg-section {
+  @apply w-[800px]
+}
+.w-sm-section {
+  @apply w-[350px]
+}
+.h-bg-section {
+  @apply h-[350px]
+}
+.h-sm-section {
+  @apply h-32
+}
+.box-default-color {
+  @apply bg-white
+}
+.box-red {
+  @apply bg-red-100
+}
+.box-blue {
+  @apply bg-blue-100
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -51,3 +51,6 @@
 }
 
 /* Box */
+.box {
+  @apply overflow-hidden border border-gray-200 shadow-md rounded-xl
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,4 +7,35 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
     './userInterface/**/*.{js,ts,jsx,tsx}',
   ],
+  theme: {
+    extend: {
+      width: {
+        12.5: '3.125rem',
+        18: '4.375rem',
+        19: '4.6875rem',
+        25: '6.25rem',
+        26: '6.5rem',
+        35: '8.75rem',
+        37.5: '9.375rem',
+        50: '12.5rem',
+        62.5: '15.625rem',
+        70: '17.5rem',
+        75: '18.75rem',
+      },
+      height: {
+        8.75: '2.1875rem',
+        15: '3.75rem',
+        25: '6.25rem',
+        37.5: '9.375rem',
+      },
+      translate: {
+        3.75: '.9375rem',
+        10: '2.5rem',
+        13.5: '3.375rem',
+        27: '6.8125rem',
+        32: '7.9375rem',
+        17: '4.25rem',
+      },
+    },
+  },
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -63,7 +63,8 @@ export type {
 export type {
   BoxProps,
   BoxColorMapper,
-  BoxSizeMapper,
+  BoxWidthMapper,
+  BoxHeightMapper,
 } from 'userInterface/box/Box.types';
 export type {
   TypographyProps,
@@ -147,9 +148,8 @@ export const TitleProps: TypographyProps = {
 };
 
 export const ErrorBoxProps: BoxProps = {
-  size: 'custom',
-  height: 'h-[300px]',
-  width: 'w-full',
+  height: 'bgSection',
+  width: 'full',
 };
 
 export const ErrorTextPropsMapper = (error: string): TypographyProps => ({

--- a/types/index.ts
+++ b/types/index.ts
@@ -146,13 +146,3 @@ export const TitleProps: TypographyProps = {
   type: 'mainTitle',
   text: '당신의 전적이 궁금하다면? Fizz.GG',
 };
-
-export const ErrorBoxProps: BoxProps = {
-  height: 'bgSection',
-  width: 'full',
-};
-
-export const ErrorTextPropsMapper = (error: string): TypographyProps => ({
-  type: 'title',
-  text: error,
-});

--- a/types/index.ts
+++ b/types/index.ts
@@ -125,7 +125,14 @@ export type ValueOf<T> = T[keyof T];
 
 export interface IconProps {
   width: number;
-  marginClass?: string;
+  mt?: number;
+  ml?: number;
+  mr?: number;
+  mb?: number;
+  pt?: number;
+  pl?: number;
+  pr?: number;
+  pb?: number;
 }
 
 export type CustomError = {

--- a/userInterface/box/Box.tsx
+++ b/userInterface/box/Box.tsx
@@ -17,9 +17,9 @@ const Box: FC<BoxProps> = ({
   marginClass = 'mb-2',
 }) => {
   const colorMapper: BoxColorMapper = {
-    default: 'bg-white',
-    red: 'bg-red-100',
-    blue: 'bg-blue-100',
+    default: 'box-default-color',
+    red: 'box-red',
+    blue: 'box-blue',
   };
 
   const widthMapper: BoxWidthMapper = {
@@ -28,8 +28,8 @@ const Box: FC<BoxProps> = ({
     large: 'w-3/5',
     xLarge: 'w-4/5',
     full: 'w-full',
-    bgSection: 'w-[800px]',
-    smSection: 'w-[300px]',
+    bgSection: 'w-bg-section',
+    smSection: 'w-sm-section',
     auto: '',
   };
 
@@ -39,8 +39,8 @@ const Box: FC<BoxProps> = ({
     large: 'h-3/5',
     xLarge: 'h-4/5',
     full: 'h-full',
-    bgSection: 'h-[350px]',
-    smSection: 'h-32',
+    bgSection: 'h-bg-section',
+    smSection: 'h-sm-section',
     auto: '',
   };
 

--- a/userInterface/box/Box.tsx
+++ b/userInterface/box/Box.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { FC } from 'react';
 
 import { BoxColorMapper, BoxProps, BoxSizeMapper } from './Box.types';
@@ -25,12 +26,14 @@ const Box: FC<BoxProps> = ({
     large: 'w-3/5',
     xLarge: 'w-4/5',
     full: 'w-full',
-    custom: width + ' ' + height,
+    custom: classNames(width, height),
   };
+
+  const className = size ? classNames( 'overflow-hidden border border-gray-200 shadow-md rounded-xl',sizeMapper[size],colorMapper[color],marginClass) : ;
 
   return (
     <section
-      className={`${sizeMapper[size]} ${colorMapper[color]} ${defaultClassName} ${marginClass}`}
+      className={className}
     >
       {children}
     </section>

--- a/userInterface/box/Box.tsx
+++ b/userInterface/box/Box.tsx
@@ -14,7 +14,10 @@ const Box: FC<BoxProps> = ({
   height = 'auto',
   hidden,
   color = 'default',
-  marginClass = 'mb-2',
+  mb = '2',
+  mr,
+  mt,
+  ml,
 }) => {
   const colorMapper: BoxColorMapper = {
     default: 'box-default-color',
@@ -45,6 +48,10 @@ const Box: FC<BoxProps> = ({
   };
 
   const hiddenMapper = hidden ? `max-${hidden}:hidden` : '';
+  const mtMapper = mt ? `mt-${mt}` : '';
+  const mbMapper = mb ? `mb-${mb}` : '';
+  const mlMapper = ml ? `ml-${ml}` : '';
+  const mrMapper = mr ? `mt-${mr}` : '';
 
   const className = classNames(
     'box',
@@ -52,7 +59,10 @@ const Box: FC<BoxProps> = ({
     heightMapper[height],
     hiddenMapper,
     colorMapper[color],
-    marginClass
+    mtMapper,
+    mrMapper,
+    mbMapper,
+    mlMapper
   );
 
   return <section className={className}>{children}</section>;

--- a/userInterface/box/Box.tsx
+++ b/userInterface/box/Box.tsx
@@ -1,43 +1,61 @@
 import classNames from 'classnames';
 import type { FC } from 'react';
 
-import { BoxColorMapper, BoxProps, BoxSizeMapper } from './Box.types';
+import {
+  BoxColorMapper,
+  BoxProps,
+  BoxWidthMapper,
+  BoxHeightMapper,
+} from './Box.types';
 
 const Box: FC<BoxProps> = ({
   children,
-  size,
-  width,
-  height,
+  width = 'auto',
+  height = 'auto',
+  hidden,
   color = 'default',
   marginClass = 'mb-2',
 }) => {
-  const defaultClassName =
-    'overflow-hidden border border-gray-200 shadow-md rounded-xl';
-
   const colorMapper: BoxColorMapper = {
     default: 'bg-white',
     red: 'bg-red-100',
     blue: 'bg-blue-100',
   };
 
-  const sizeMapper: BoxSizeMapper = {
+  const widthMapper: BoxWidthMapper = {
     small: 'w-1/4',
     medium: 'w-2/5',
     large: 'w-3/5',
     xLarge: 'w-4/5',
     full: 'w-full',
-    custom: classNames(width, height),
+    bgSection: 'w-[800px]',
+    smSection: 'w-[300px]',
+    auto: '',
   };
 
-  const className = size ? classNames( 'overflow-hidden border border-gray-200 shadow-md rounded-xl',sizeMapper[size],colorMapper[color],marginClass) : ;
+  const heightMapper: BoxHeightMapper = {
+    small: 'h-1/4',
+    medium: 'h-2/5',
+    large: 'h-3/5',
+    xLarge: 'h-4/5',
+    full: 'h-full',
+    bgSection: 'h-[350px]',
+    smSection: 'h-32',
+    auto: '',
+  };
 
-  return (
-    <section
-      className={className}
-    >
-      {children}
-    </section>
+  const hiddenMapper = hidden ? `max-${hidden}:hidden` : '';
+
+  const className = classNames(
+    'box',
+    widthMapper[width],
+    heightMapper[height],
+    hiddenMapper,
+    colorMapper[color],
+    marginClass
   );
+
+  return <section className={className}>{children}</section>;
 };
 
 export default Box;

--- a/userInterface/box/Box.types.ts
+++ b/userInterface/box/Box.types.ts
@@ -1,21 +1,34 @@
 import { ReactNode } from 'react';
 
 export interface BoxProps {
-  size?: keyof BoxSizeMapper;
   color?: keyof BoxColorMapper;
-  width?: string;
-  height?: string;
+  width?: keyof BoxWidthMapper;
+  height?: keyof BoxHeightMapper;
   children?: ReactNode;
   marginClass?: string;
+  hidden?: string;
 }
 
-export type BoxSizeMapper = {
-  small: string;
-  medium: string;
-  large: string;
-  xLarge: string;
-  full: string;
-  custom: string;
+export type BoxWidthMapper = {
+  small: 'w-1/4';
+  medium: 'w-2/5';
+  large: 'w-3/5';
+  xLarge: 'w-4/5';
+  full: 'w-full';
+  bgSection: 'w-[800px]';
+  smSection: 'w-[300px]';
+  auto: '';
+};
+
+export type BoxHeightMapper = {
+  small: 'h-1/4';
+  medium: 'h-2/5';
+  large: 'h-3/5';
+  xLarge: 'h-4/5';
+  full: 'h-full';
+  bgSection: 'h-[350px]';
+  smSection: 'h-32';
+  auto: '';
 };
 
 export type BoxColorMapper = {

--- a/userInterface/box/Box.types.ts
+++ b/userInterface/box/Box.types.ts
@@ -15,8 +15,8 @@ export type BoxWidthMapper = {
   large: 'w-3/5';
   xLarge: 'w-4/5';
   full: 'w-full';
-  bgSection: 'w-[800px]';
-  smSection: 'w-[300px]';
+  bgSection: 'w-bg-section';
+  smSection: 'w-sm-section';
   auto: '';
 };
 
@@ -26,13 +26,13 @@ export type BoxHeightMapper = {
   large: 'h-3/5';
   xLarge: 'h-4/5';
   full: 'h-full';
-  bgSection: 'h-[350px]';
-  smSection: 'h-32';
+  bgSection: 'h-bg-section';
+  smSection: 'h-sm-section';
   auto: '';
 };
 
 export type BoxColorMapper = {
-  default: 'bg-white';
-  red: 'bg-red-100';
-  blue: 'bg-blue-100';
+  default: 'box-default-color';
+  red: 'box-red';
+  blue: 'box-blue';
 };

--- a/userInterface/box/Box.types.ts
+++ b/userInterface/box/Box.types.ts
@@ -5,10 +5,10 @@ export interface BoxProps {
   width?: keyof BoxWidthMapper;
   height?: keyof BoxHeightMapper;
   children?: ReactNode;
-  mb?: string | number;
-  mt?: string | number;
-  ml?: string | number;
-  mr?: string | number;
+  mb?: 'auto' | number;
+  mt?: 'auto' | number;
+  ml?: 'auto' | number;
+  mr?: 'auto' | number;
   hidden?: string;
 }
 

--- a/userInterface/box/Box.types.ts
+++ b/userInterface/box/Box.types.ts
@@ -5,7 +5,10 @@ export interface BoxProps {
   width?: keyof BoxWidthMapper;
   height?: keyof BoxHeightMapper;
   children?: ReactNode;
-  marginClass?: string;
+  mb?: string | number;
+  mt?: string | number;
+  ml?: string | number;
+  mr?: string | number;
   hidden?: string;
 }
 

--- a/userInterface/box/Box.types.ts
+++ b/userInterface/box/Box.types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 export interface BoxProps {
-  size: keyof BoxSizeMapper;
+  size?: keyof BoxSizeMapper;
   color?: keyof BoxColorMapper;
   width?: string;
   height?: string;

--- a/userInterface/button/Button.tsx
+++ b/userInterface/button/Button.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { FC } from 'react';
 
 import {
@@ -13,24 +14,25 @@ const Button: FC<ButtonProps> = ({
   size = 'medium',
   type = 'button',
 }) => {
-  const defaultVariants = 'font-medium rounded-lg';
-  const colorVariants: ButtonColorMapper = {
-    blue: 'text-white bg-blue-700 hover:bg-blue-500  ',
-    gray: '',
-    transparent: 'hover:border-blue-500 border-transparent border-2 rounded-lg',
+  const colorMapper: ButtonColorMapper = {
+    blue: 'button-blue',
+    gray: 'button-gray',
+    transparent: 'button-transparent',
   };
-  const sizeVariants: ButtonSizeMapper = {
-    small: '',
-    medium: 'px-4 py-2 text-sm ',
-    large: '',
+  const sizeMapper: ButtonSizeMapper = {
+    small: 'button-small',
+    medium: 'button-medium ',
+    large: 'button-large',
   };
 
+  const className = classNames(
+    'font-medium rounded-lg px-4 py-2',
+    colorMapper[color],
+    sizeMapper[size]
+  );
+
   return (
-    <button
-      type={type}
-      onClick={onClick}
-      className={`${defaultVariants} ${sizeVariants[size]} ${colorVariants[color]}`}
-    >
+    <button type={type} onClick={onClick} className={className}>
       {label}
     </button>
   );

--- a/userInterface/button/button.test.tsx
+++ b/userInterface/button/button.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+
+import Button from './Button';
+
+test('Button test', () => {
+  render(<Button label='Button' onClick={() => {}} />);
+
+  expect(screen.getByText('Button')).toHaveTextContent('Button');
+});

--- a/userInterface/input/Input.tsx
+++ b/userInterface/input/Input.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { FC } from 'react';
 
 import {
@@ -16,15 +17,22 @@ const Input: FC<InputProps> = ({
   color = 'gray',
   required,
 }) => {
-  const colorVariants: InputBorderColorMapper = {
-    blue: '',
-    gray: 'border border-gray-300 rounded-lg focus:border-blue-500',
+  const colorMapper: InputBorderColorMapper = {
+    blue: 'input-blue',
+    gray: 'input-gray',
   };
-  const sizeVariants: InputSizeMapper = {
-    small: '',
-    medium: 'w-3/5 p-4 pl-10 text-sm ',
-    big: '',
+
+  const sizeMapper: InputSizeMapper = {
+    small: 'input-small',
+    medium: 'input-medium',
+    large: 'input-large',
   };
+
+  const className = classNames(
+    'rounded-lg p-4 pl-10',
+    sizeMapper[size],
+    colorMapper[color]
+  );
   return (
     <>
       <label htmlFor={labelFor} />
@@ -34,7 +42,7 @@ const Input: FC<InputProps> = ({
         disabled={disabled}
         value={value}
         id={labelFor}
-        className={`${sizeVariants[size]} ${colorVariants[color]}`}
+        className={className}
         required={required}
       />
     </>

--- a/userInterface/input/Input.types.ts
+++ b/userInterface/input/Input.types.ts
@@ -19,5 +19,5 @@ export type InputBorderColorMapper = {
 export type InputSizeMapper = {
   small: string;
   medium: string;
-  big: string;
+  large: string;
 };

--- a/userInterface/typography/Typography.tsx
+++ b/userInterface/typography/Typography.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import classNames from 'classnames';
 
 import {
   TypoGraphyColorMapper,
@@ -15,10 +16,9 @@ const Typography: FC<TypographyProps> = ({
   color = 'black',
 }) => {
   const typeMapper: TypographyTypeMapper = {
-    mainTitle:
-      'bg-gradient-to-br from-black to-stone-500 bg-clip-text text-center text-6xl font-bold tracking-[-0.02em] text-transparent drop-shadow-sm leading-[5rem] my-20',
-    title: 'text-2xl font-medium',
-    semibold: 'font-semibold',
+    mainTitle: 'main-title',
+    title: 'title',
+    semibold: 'semi-bold',
     default: '',
   };
 
@@ -35,8 +35,11 @@ const Typography: FC<TypographyProps> = ({
     gray: 'text-gray-600',
   };
 
-  const className =
-    typeMapper[type] + ' ' + sizeMapper[size] + ' ' + colorMapper[color];
+  const className = classNames(
+    typeMapper[type],
+    sizeMapper[size],
+    colorMapper[color]
+  );
 
   if (isTitle) {
     return <h1 className={className}>{text}</h1>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,6 +1711,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"


### PR DESCRIPTION
# 변경점

- 컴포넌트의 옵션들 Tailwind apply로 커스텀클래스 생성(Input, Typography, Box, Button)
- 기존 margin으로 한번에 받던 컴포넌트 옵션들 ml,mt,mb,mr,pt,pl.pb.pr로 패딩 마진 따로따로 받게 수정
- 800px, 300px 등 자주쓰이는 단위를 클래스로 따로 지정
- 4px단위로 tailwind.config 에서 설정으로 width,height,translate Fixed number 추가
